### PR TITLE
add info about double

### DIFF
--- a/docs/schema/model.md
+++ b/docs/schema/model.md
@@ -32,7 +32,7 @@ Currently we support following column types
 - Uuid
 - String
 - Int
-- Double
+- Double (IEEE 64-bit float)
 - Bool
 - Enum 
 - DateTime


### PR DESCRIPTION
For reference see:
- https://github.com/contember/contember/blob/55220ff69ab4a873b063adc45318a5c15ee0117a/packages/schema-definition/src/model/utils/getColumnType.ts#L9
- https://www.postgresql.org/docs/current/datatype-numeric.html
- https://tc39.es/ecma262/#sec-mathematical-operations
- https://spec.graphql.org/June2018/#sec-Float